### PR TITLE
Remove setuptools_scm

### DIFF
--- a/.github/workflows/python_test_deploy.yml
+++ b/.github/workflows/python_test_deploy.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, ]  # Only Linux for _creation_]
+        os: [ubuntu, macos, windows]
         case:
           - python-version: 3.8
 
@@ -37,10 +37,15 @@ jobs:
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.case.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools_scm numpy pytest pytest-flake8
+          pip install numpy pytest pytest-flake8
 
       - name: Create, install, lint and test
         run: |
@@ -70,26 +75,20 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.case.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install wheel setuptools_scm numpy
+          pip install wheel numpy
 
       - name: Create package
         run: |
           cd packages
           python create_python.py
-
-      - name: Replace naming scheme
-        if: github.ref == 'refs/heads/main'
-        run: |
-          # Change setuptools-scm local_scheme to "no-local-version" so the
-          # local part of the version isn't included, making the version string
-          # compatible with Test PyPI.
-          sed --in-place 's/"root"/"local_scheme":"no-local-version","root"/g' packages/python/setup.py
-          cat packages/python/setup.py
+          echo ""
+          echo "Version:"
+          echo python python/setup.py --version
 
       - name: Build source and wheel distributions
         run: |

--- a/.github/workflows/python_test_deploy.yml
+++ b/.github/workflows/python_test_deploy.yml
@@ -1,4 +1,4 @@
-name: linux-python
+name: python
 
 on:
   pull_request:

--- a/packages/README.md
+++ b/packages/README.md
@@ -13,13 +13,12 @@ The python package is created by running
 python create_python.py
 ```
 
-The build requires `setuptools_scm`; the only dependency to use the package is
-`numpy`.
+The only dependency to use the package is `numpy`.
 
 If you want to install the package created in this manner, run
 
 ```bash
-pip install  python/. --use-feature=in-tree-build
+pip install python/. --use-feature=in-tree-build
 ```
 
 To clear it, run


### PR DESCRIPTION
To streamline with other packages we should use simply `git describe` to get the version number:

```
git describe --tags
```

The implementation is
```
version = subprocess.check_output(
    ['git', 'describe', '--tags'], stderr=subprocess.DEVNULL
).strip().decode('utf-8').split('-')
if len(version) > 1 and version[1]:
    version = version[0][1:] + '.dev' + version[1]
else:
    version = version[0][1:]
```

What it does:
- Remove the `v`, as Python wants a pure semantic number.  
  E.g.: `v0.0.4` => `0.0.4`
- Adds the `.dev`-just for test releases to TestPyPI (does not accept hyphens as comes from `git describe`); cuts the hash.  
  E.g. `v0.0.4-5-gc821797` => `0.0.4.dev5`